### PR TITLE
get it to build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ stages:
             enablePublishTestResults: true
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                name: NetCore1ESPool-Public
+                # name: NetCore1ESPool-Public
                 demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Internal
@@ -198,7 +198,7 @@ stages:
             timeoutInMinutes: 180
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                name: NetCore1ESPool-Public
+                # name: NetCore1ESPool-Public
                 demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Internal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,7 @@ stages:
   jobs:
     - template: eng/common/templates/jobs/jobs.yml
       parameters:
+        runAsPublic: true
         enableMicrobuild: true
         enablePublishBuildArtifacts: true
         enablePublishBuildAssets: true


### PR DESCRIPTION
TL;DR: don't do this - just build and test locally:
https://github.com/neilboyd/efcore/blob/main/docs/getting-and-building-the-code.md
If I make a PR to origin then it'll build it.

---

I need to create an agent pool named `NetCore1ESPool-Internal`.

https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/scale-set-agents?view=azure-devops

I don't think I really want to do that. It's hard and will cost money.

If I make it public then I need to request parallelism: https://aka.ms/azpipelines-parallelism-request. It asks for justification:
![image](https://user-images.githubusercontent.com/1768373/161898471-3db1ee99-bdef-4429-8fda-34b1e2d4ef05.png)

The public builds take a long time:
https://dev.azure.com/dnceng/public/_build?definitionId=51
![image](https://user-images.githubusercontent.com/1768373/161898752-0d58eccf-589b-4241-aa10-f9573d329bb1.png)

Or I could setup billing and get 1800 free minutes:
https://dev.azure.com/neilboyd/_settings/billing
![image](https://user-images.githubusercontent.com/1768373/161900239-6a118801-e137-472b-9525-d2fd65c21406.png)

